### PR TITLE
Remove running of non-existent sql file. Add volume for needed shell script

### DIFF
--- a/deploy/deploy.conf.sh
+++ b/deploy/deploy.conf.sh
@@ -18,17 +18,17 @@ declare -a REPO_NAMES=(\
 )
 
 declare -A REPO_URL_MAP=(\
-  [gamechanger-web]="https://github.com/dod-advana/gamechanger-web" \
-  [gamechanger-data]="https://github.com/dod-advana/gamechanger-data.git" \
-  [gamechanger-ml]="https://github.com/dod-advana/gamechanger-ml.git" \
+  [gamechanger-web]="https://github.com/shanedell/gamechanger-web" \
+  [gamechanger-data]="https://github.com/shanedell/gamechanger-data.git" \
+  [gamechanger-ml]="https://github.com/shanedell/gamechanger-ml.git" \
   [gamechanger-neo4j-plugin]="https://github.com/dod-advana/gamechanger-neo4j-plugin.git" \
   [gamechanger-crawlers]="https://github.com/dod-advana/gamechanger-crawlers.git" \
 )
 
 declare -A REPO_TAG_MAP=(\
-  [gamechanger-web]="dev" \
-  [gamechanger-data]="dev" \
-  [gamechanger-ml]="dev" \
+  [gamechanger-web]="patch-yarnlock-docker-prod" \
+  [gamechanger-data]="patch-dockerfiles" \
+  [gamechanger-ml]="patch-reqs" \
   [gamechanger-neo4j-plugin]="main" \
   [gamechanger-crawlers]="dev" \
 )

--- a/deploy/docker-compose/services.yaml
+++ b/deploy/docker-compose/services.yaml
@@ -26,7 +26,8 @@ services:
       S3_ACCESS_KEY: "dev-access-key"
       S3_SECRET_KEY: "dev-secret-key"
       S3_ENDPOINT: "http://s3-server:9000"
-  
+    volumes:
+      - "./deploy/build/gamechanger-web/generateCombinedEnv.sh/:/opt/app-root/src/generateCombinedEnv.sh:Z"
     depends_on:
       - redis
       - postgres

--- a/deploy/docker-compose/utils.yaml
+++ b/deploy/docker-compose/utils.yaml
@@ -132,7 +132,6 @@ services:
       - "./deploy/build/gamechanger-web/backend/node_app/init/:/tmp/sql/:Z"
     command:
       - |
-        psql -f /tmp/sql/pop_mini_RE.sql
         psql -f /tmp/sql/create_admins.sql
     networks:
       - app-net


### PR DESCRIPTION
## Reasoning for PR

Issues addressed:

1. File `pop_mini_RE.sql` was removed from gamerchanger-web in [this commit](https://github.com/dod-advana/gamechanger-web/commit/2e319f0f4f6b5196ae9723f5672f29bc3044c8e4#diff-41eb37676161887f086e61fde1ce258e3ec441fe4f7e7bb32b26ebd0b727e40e). So it was removed from compose.
    - Should the file be added back into gamechanger-web instead?
2. `generateCombinedEnv.sh` was not being copied into the container image for gamechanger-web and not volumed in. Added volume for the file in the docker-compose.
    - Should it instead be copied into the image via `Dockerfile.prod` in [gamechanger-web](https://github.com/dod-advana/gamechanger-web)?

## Question

Should gamechanger-data's default branch be `main` instead of `dev`? `dev` seems to be 20 commits behind `main`. I can revert the repository url's and branches back to the original once (possibly changing `dev` to `main` for gamechanger-data) the other PRs are merged into the appropriate branches.

## Accompanying PRs

- [gamechanger-data PR](https://github.com/dod-advana/gamechanger-data/pull/308)
- [gamechanger-ml PR](https://github.com/dod-advana/gamechanger-ml/pull/159)
- [gamechanger-web PR](https://github.com/dod-advana/gamechanger-web/pull/604)
